### PR TITLE
Version info in help, Group by weeks

### DIFF
--- a/gitbars/gitbars.py
+++ b/gitbars/gitbars.py
@@ -50,13 +50,15 @@ def filter(items, periodicity="day", author=""):
         # Extract the day/month/year part of the date.
         p = i["timestamp"][:10]
         is_weekend = False
-        if periodicity == "month":
+        if periodicity == "week":
+            p = datetime.datetime.strptime(p, "%Y-%m-%d").strftime("%V")
+        elif periodicity == "month":
             p = i["timestamp"][:7]
         elif periodicity == "year":
             p = i["timestamp"][:4]
         else:
             is_weekend = (datetime.datetime.
-                          strptime(i["timestamp"][:10], "%Y-%m-%d").
+                          strptime(p, "%Y-%m-%d").
                           weekday() > 4)
         # Filter by author.
         if author != "":
@@ -122,7 +124,7 @@ def main():
                                 "Weekends are coloured. (version " + __version__ + ")")
     p.add_argument("-p", "--periodicity", action="store", dest="periodicity",
                    type=str, required=False, default="month",
-                   help="day, month, year")
+                   help="day, week, month, year")
 
     p.add_argument("-u", "--author", action="store", dest="author",
                    type=str, required=False, default="",

--- a/gitbars/gitbars.py
+++ b/gitbars/gitbars.py
@@ -18,6 +18,8 @@ import argparse
 from collections import OrderedDict
 import datetime
 
+import pkg_resources
+__version__ = pkg_resources.require("git-bars")[0].version
 
 def print_bars(items, block=u"\u2580", width=50):
     """Print unicode bar representations of dates and scores."""
@@ -117,7 +119,7 @@ def normalize(x, xmin, xmax):
 def main():
     """Commandline entry point."""
     p = argparse.ArgumentParser(description="Shows git commit count bars. "
-                                "Weekends are coloured.")
+                                "Weekends are coloured. (version " + __version__ + ")")
     p.add_argument("-p", "--periodicity", action="store", dest="periodicity",
                    type=str, required=False, default="month",
                    help="day, month, year")

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="git-bars",
-    version="1.4",
+    version="1.5",
     description="A utility for visualising git commit activity as bars on the terminal",
     author="Kailash Nadh",
     author_email="kailash@nadh.in",


### PR DESCRIPTION
After a recent update I wanted to check the version of the project currently installed, so I have added this information in `git-bars --help` to ease this.

My project was recently started and neither month nor day was helpful for me, week support would be very helpful.