### PR TITLE
Add optional argument with path to Git repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 `git-bars` is a utility that uses `git log` to render a simple git commit activity bars on the terminal. Commit activity can be grouped by day, month, year, between two dates, and can be filtered by author.
 
 ```shell
-$> cd /path/to/a/git/repo
-$> git-bars -p day
+$> git-bars -p day /path/to/a/git/repo
 
 78 commits
 2018-11-27 4    ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀

--- a/gitbars/gitbars.py
+++ b/gitbars/gitbars.py
@@ -96,10 +96,12 @@ def get_scores(items):
     return out
 
 
-def get_log(after, before, reverse=False, fill=False):
+def get_log(repo, after, before, reverse=False, fill=False):
     """Return the list of git log from the git log command."""
     # 2018-01-01 00:00:00|author@author.com
     args = ["git", "log", "--pretty=format:%ai|%ae", "--reverse"]
+    if repo:
+        args = args[0] + f"-C {repo}" + args[1:]
 
     if after:
         args.append("--after=%s" % (after,))
@@ -170,12 +172,16 @@ def main():
                    type=bool, required=False, default=False,
                    help="fill dates (with no commits) on the graph")
 
+    p.add_argument("repo", type=str, nargs='?', default="",
+                   help="Path to a git repository")
+
     args = p.parse_args()
 
     """Invoke the utility."""
     items = []
     try:
-        items = get_log(args.after, args.before, args.reverse, args.fill)
+        items = get_log(args.after, args.before, args.reverse, args.fill,
+                        args.repo)
     except Exception as e:
         print("error running 'git log': %s" % (e,))
         return

--- a/gitbars/gitbars.py
+++ b/gitbars/gitbars.py
@@ -101,7 +101,7 @@ def get_log(repo, after, before, reverse=False, fill=False):
     # 2018-01-01 00:00:00|author@author.com
     args = ["git", "log", "--pretty=format:%ai|%ae", "--reverse"]
     if repo:
-        args = args[0] + f"-C {repo}" + args[1:]
+        args = [args[0]] + ["-C", f'{repo}'] + args[1:]
 
     if after:
         args.append("--after=%s" % (after,))
@@ -180,8 +180,8 @@ def main():
     """Invoke the utility."""
     items = []
     try:
-        items = get_log(args.after, args.before, args.reverse, args.fill,
-                        args.repo)
+        items = get_log(args.repo, args.after, args.before, args.reverse,
+                        args.fill)
     except Exception as e:
         print("error running 'git log': %s" % (e,))
         return

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="git-bars",
-    version="1.7",
+    version="1.8",
     description="A utility for visualising git commit activity as bars on the terminal",
     author="Kailash Nadh",
     author_email="kailash@nadh.in",


### PR DESCRIPTION
I added an optional positional argument so that users can point to repositories somewhere in the file system. In case no argument for a path to a repository is given, the behavior is as it is prior to this change, i.e., a user has to change directory to a Git repository explicitly before invoking the tool.